### PR TITLE
docs: fix typos

### DIFF
--- a/docs/EN/appendix/import-links.md
+++ b/docs/EN/appendix/import-links.md
@@ -274,7 +274,7 @@ With similarly:
 
 ## metrics et metricsB
 
-- **metrics** : This is a metric table to add auxilary metrics.
+- **metrics** : This is a metric table to add auxiliary metrics.
   - **0**
     - **expr** : Expression in PrompQL
     - **format** : (Leaves blank)

--- a/docs/EN/appendix/import-point.md
+++ b/docs/EN/appendix/import-point.md
@@ -274,7 +274,7 @@ With similarly:
 
 ## metrics
 
-- **metrics** : This is a metric table to add auxilary metrics.
+- **metrics** : This is a metric table to add auxiliary metrics.
   - **0**
     - **expr** : Expression in PrompQL
     - **format** : (Leaves blank)

--- a/docs/EN/appendix/import-region.md
+++ b/docs/EN/appendix/import-region.md
@@ -294,7 +294,7 @@ Compatible format is JPG / PNG / GIF / SVG
 
 ## metrics
 
-- **metrics** This is a metric table to add auxilary metrics.
+- **metrics** This is a metric table to add auxiliary metrics.
 
   - **0**
 

--- a/docs/EN/editor/coordinates-position-parameter.md
+++ b/docs/EN/editor/coordinates-position-parameter.md
@@ -77,7 +77,7 @@ Part B
 the `Layer lavel` parameter is only available for the `OrientedLink` tab. You can perform the following operation : 
 
 
-  - Upgrade on : choose the other link that you want to see bellow this one
+  - Upgrade on : choose the other link that you want to see below this one
   - Downgrade on : choose the other link that you want to see above this one
   
 

--- a/src/Functions/searchIDLimit.tsx
+++ b/src/Functions/searchIDLimit.tsx
@@ -24,7 +24,7 @@ export interface Coor4DNum {
 //   return false;
 // };
 
-// /** search all coordinate if atribute is d */
+// /** search all coordinate if attribute is d */
 // const searchOtherLimitDAttribute = (data: string, limit: number[]): boolean => {
 //   const parseWithLetter = [];
 //   const regex = /[a-zA-Z]{1}[0-9.\W]*/g;

--- a/src/components/CoordinateSpace/coordinateSpace.tsx
+++ b/src/components/CoordinateSpace/coordinateSpace.tsx
@@ -459,7 +459,7 @@ class CoordinateSpace extends React.Component<Props, State> {
   };
 
   /**
-   * fill input whith data
+   * fill input with data
    * this function is called by mount and update event
    */
   getDataInInput = async () => {

--- a/src/components/CoordinateSpace/editCoordinateSpace.tsx
+++ b/src/components/CoordinateSpace/editCoordinateSpace.tsx
@@ -85,7 +85,7 @@ class EditCoordinateSpace extends React.Component<Props, State> {
     });
   };
 
-  /** fill select whith array region object */
+  /** fill select with array region object */
   fillSelectRegionSpace = () => {
     let valueExist = false;
     const valueSelect: SelectRegion[] = [];

--- a/src/components/CoordinateSpace/orientedLink/editOrientedLink.tsx
+++ b/src/components/CoordinateSpace/orientedLink/editOrientedLink.tsx
@@ -85,7 +85,7 @@ class EditOrientedLink extends React.Component<Props, State> {
     });
   };
 
-  /** fill select whith array region object */
+  /** fill select with array region object */
   fillSelectOrientedLink = () => {
     let valueExist = false;
     const valueSelect: SelectOrientedLink[] = [];

--- a/src/components/CoordinateSpace/orientedLink/orientedLink.tsx
+++ b/src/components/CoordinateSpace/orientedLink/orientedLink.tsx
@@ -568,7 +568,7 @@ export default class OrientedLink extends React.Component<Props, State> {
     });
   };
   /**
-   * fill input whith data
+   * fill input with data
    * this function is called by mount and update event
    */
   getDataInInput = async () => {

--- a/src/components/CoordinateSpace/point/editPoint.tsx
+++ b/src/components/CoordinateSpace/point/editPoint.tsx
@@ -86,7 +86,7 @@ class EditPoint extends React.Component<Props, State> {
     });
   };
 
-  /** fill select whith array region object */
+  /** fill select with array region object */
   fillSelectPoint = () => {
     let valueExist = false;
     const valueSelect: SelectPoint[] = [];

--- a/src/components/CoordinateSpace/point/point.tsx
+++ b/src/components/CoordinateSpace/point/point.tsx
@@ -386,7 +386,7 @@ export default class Point extends React.Component<Props, State> {
   };
 
   /**
-   * fill input whith data
+   * fill input with data
    * this function is called by mount and update event
    */
   getDataInInput = async () => {

--- a/src/components/Parametrage/VariableColor.tsx
+++ b/src/components/Parametrage/VariableColor.tsx
@@ -67,7 +67,7 @@ class VariableColor extends React.Component<Props, State, PanelEditorProps<Simpl
   }
 
   /**
-   * set state for arrayInputClass whith Promise
+   * set state for arrayInputClass with Promise
    */
   setStateAsyncArrayInputClass = (state: {
     /**
@@ -81,7 +81,7 @@ class VariableColor extends React.Component<Props, State, PanelEditorProps<Simpl
   };
 
   /**
-   * set state for seuil whith Promise
+   * set state for seuil with Promise
    */
   setStateAsyncLowerLimit = (state: {
     /**
@@ -95,7 +95,7 @@ class VariableColor extends React.Component<Props, State, PanelEditorProps<Simpl
   };
 
   /**
-   * set state for index whith Promise
+   * set state for index with Promise
    */
   setStateAsyncIndex = (state: {
     /**
@@ -109,7 +109,7 @@ class VariableColor extends React.Component<Props, State, PanelEditorProps<Simpl
   };
 
   /**
-   * set state for nbVariation whith Promise
+   * set state for nbVariation with Promise
    */
   setStateAsyncNbVariation = (state: {
     /**

--- a/src/components/Parametrage/manageLink.tsx
+++ b/src/components/Parametrage/manageLink.tsx
@@ -40,7 +40,7 @@ class ManageLink extends React.Component<Props, State> {
   }
 
   /**
-   * edit followLink whith Promise
+   * edit followLink with Promise
    */
   setStateAsyncFollowLink = (state: {
     /**
@@ -54,7 +54,7 @@ class ManageLink extends React.Component<Props, State> {
   };
 
   /**
-   * edit link for tooltip whith Promise
+   * edit link for tooltip with Promise
    */
   setStateAsyncHoveringTooltipLink = (state: {
     /**
@@ -68,7 +68,7 @@ class ManageLink extends React.Component<Props, State> {
   };
 
   /**
-   * edit text for tooltip whith Promise
+   * edit text for tooltip with Promise
    */
   setStateAsyncHoveringTooltipText = (state: {
     /**

--- a/src/components/legend.tsx
+++ b/src/components/legend.tsx
@@ -113,14 +113,14 @@ class LegendComponent extends React.Component<Props, State> {
     // const close = document.getElementById('iconclose');
     // close?.addEventListener('click', () => {
 
-    //   const disapear = document.getElementById('L');
+    //   const disappear = document.getElementById('L');
     //   const appear = document.getElementById('legnd');
-    //   if (disapear) {
-    //     disapear.style.visibility = 'hidden';
+    //   if (disappear) {
+    //     disappear.style.visibility = 'hidden';
     //   }
     //   appear?.addEventListener('click', () => {
-    //     if (disapear) {
-    //       disapear.style.visibility = 'visible';
+    //     if (disappear) {
+    //       disappear.style.visibility = 'visible';
     //     }
     //   });
     // });

--- a/src/components/spec/ImporInput.test.tsx
+++ b/src/components/spec/ImporInput.test.tsx
@@ -1174,7 +1174,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('pointUpdate', () => {
-//     test('Expecto to arrayPoints have been updated in teh good way', done => {
+//     test('Expecto to arrayPoints have been updated in the good way', done => {
 //       component.props.options.arrayPoints = [];
 //       const goodInput = new PointClass(
 //         point.id,
@@ -1248,7 +1248,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('regionUpdate', () => {
-//     test('Expecto to regionCoordinateSpace have been updated in teh good way', done => {
+//     test('Expecto to regionCoordinateSpace have been updated in the good way', done => {
 //       const goodInput = new RegionClass(
 //         regionCoods.id,
 //         regionCoods.linkURL,
@@ -1305,7 +1305,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('linkUpdate', () => {
-//     test('Expecto to arrayOrientedLinks have been updated in teh good way', done => {
+//     test('Expecto to arrayOrientedLinks have been updated in the good way', done => {
 //       const goodInput = new OrientedLinkClass(
 //         link.id,
 //         link.linkURL,
@@ -2167,7 +2167,7 @@ describe('waiting test', () => {
 //});
 
 // describe('fonction name', () => {
-//   test('Explaination and expect return', (done) => {
+//   test('Explanation and expect return', (done) => {
 //     //input and preparation for test
 //     const spy = jest.spyOn(component, 'function name');
 //     const result = component.function(input);
@@ -3291,7 +3291,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('pointUpdate', () => {
-//     test('Expecto to arrayPoints have been updated in teh good way', (done) => {
+//     test('Expecto to arrayPoints have been updated in the good way', (done) => {
 //       component.props.options.arrayPoints = [];
 //       const goodInput = new PointClass(
 //         point.id,
@@ -3357,7 +3357,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('regionUpdate', () => {
-//     test('Expecto to regionCoordinateSpace have been updated in teh good way', (done) => {
+//     test('Expecto to regionCoordinateSpace have been updated in the good way', (done) => {
 //       const goodInput = new RegionClass(
 //         regionCoods.id,
 //         regionCoods.linkURL,
@@ -3408,7 +3408,7 @@ describe('waiting test', () => {
 //   });
 
 //   describe('linkUpdate', () => {
-//     test('Expecto to arrayOrientedLinks have been updated in teh good way', (done) => {
+//     test('Expecto to arrayOrientedLinks have been updated in the good way', (done) => {
 //       const goodInput = new OrientedLinkClass(
 //         link.id,
 //         link.linkURL,
@@ -4142,7 +4142,7 @@ describe('waiting test', () => {
 //     });
 //   });
 //   // describe('fonction name', () => {
-//   //   test('Explaination and expect return', done => {
+//   //   test('Explanation and expect return', done => {
 //   //     //input and preparation for test
 //   //     const spy = jest.spyOn(component, 'function name');
 //   //     const result = component.function(input);


### PR DESCRIPTION
Hi,

This huge PR will fix : 

- 1 typo in `docs/EN/appendix/import-links.md`
- 1 typo in `docs/EN/appendix/import-point.md`
- 1 typo in `docs/EN/appendix/import-region.md`
- 1 typo in `docs/EN/editor/coordinates-position-parameter.md`
- 1 typo in `src/Functions/searchIDLimit.tsx`
- 1 typo in `src/components/CoordinateSpace/coordinateSpace.tsx`
- 1 typo in `src/components/CoordinateSpace/editCoordinateSpace.tsx`
- 1 typo in `src/components/CoordinateSpace/orientedLink/editOrientedLink.tsx`
- 1 typo in `src/components/CoordinateSpace/orientedLink/orientedLink.tsx`
- 1 typo in `src/components/CoordinateSpace/point/editPoint.tsx`
- 1 typo in `src/components/CoordinateSpace/point/point.tsx`
- 4 typos in `src/components/Parametrage/VariableColor.tsx`
- 3 typos in `src/components/Parametrage/manageLink.tsx`
- 5 typos in `src/components/legend.tsx`
- 8 typos in `src/components/spec/ImporInput.test.tsx`



Ciao! :robot: